### PR TITLE
Fix booting and grub, add missing packages

### DIFF
--- a/mod-check
+++ b/mod-check
@@ -1,7 +1,44 @@
 #!/bin/bash
 
-SUBVOLS=".snapshots boot/grub2/i386-pc boot/grub2/x86_64-efi boot/writable home opt root srv usr/local var"
-PACKAGES="patterns-microos-base patterns-microos-base-zypper patterns-microos-defaults patterns-microos-hardware patterns-microos-desktop-gnome patterns-containers-container_runtime patterns-base-bootloader accountsservice-lang irqbalance iso-codes-lang kernel-default numactl os-prober sg3_utils nvme-cli"
+SUBVOLS="
+	.snapshots
+	boot/grub2/i386-pc
+	boot/grub2/x86_64-efi
+	boot/writable
+	home
+	opt
+	root
+	srv
+	usr/local
+	var
+"
+
+PACKAGES="
+	patterns-base-bootloader
+	patterns-containers-container_runtime
+	patterns-microos-base
+	patterns-microos-base-zypper
+	patterns-microos-defaults
+	patterns-microos-desktop-gnome
+	patterns-microos-hardware
+	patterns-microos-selinux
+	accountsservice-lang
+	irqbalance
+	iso-codes-lang
+	kernel-default
+	numactl
+	nvme-cli
+	os-prober
+	sg3_utils
+	grub2-i386-pc-extras
+	grub2-x86_64-efi-extras
+"
+
+# Missing packages:
+#	firmwares (maybe using -all?)
+# 	ucode-amd/ucode-intel
+# 	xf86-video-r128/intel, VM/Guest-tools
+# This stuff is decided during yast installation.
 
 TMPMNT=$(mktemp -d)
 RUNDATE=$(date '+%Y-%m-%d %T')
@@ -35,30 +72,37 @@ if [ "${ID%%[ ]*}" != "opensuse-microos" ]; then
 fi
 
 if [ "$EUID" -ne 0 ]; then
-        sudo "$0" "$@"
-        exit
+	sudo "$0" "$@"
+	exit
 fi
 
 print_red "This is a prototype script that may do terrible things to your system, you have been warned"
 read -p "Do you want to continue? (yes/no) " yn
 case $yn in
-	yes ) print_green "OK";;
-	no ) echo exiting...;
-		exit;;
-	* ) echo invalid response;
-		exit 1;;
+	yes) print_green "OK" ;;
+	no)
+		echo exiting...
+		exit
+		;;
+	*)
+		echo invalid response
+		exit 1
+		;;
 esac
 
 print_yellow "DEMO: Create New MicroOS Desktop (GNOME) Installation in fresh subvolume. Fool tukit/snapper into thinking its a valid snapshot"
 
 # Create snapshot
 LATESTSNAP=$(tukit -q snapshots | tail -n1)
-WORKSNAP=$((LATESTSNAP+1))
+WORKSNAP=$((LATESTSNAP + 1))
 mkdir /.snapshots/$WORKSNAP
 btrfs subvolume create /.snapshots/$WORKSNAP/snapshot
 
+mkdir -p /.snapshots/$WORKSNAP/snapshot/boot/writable
+mkdir -p /.snapshots/$WORKSNAP/snapshot/.snapshots
+
 # Create dummy snapper XML
-cat <<EOF > /.snapshots/$WORKSNAP/info.xml
+cat << EOF > /.snapshots/$WORKSNAP/info.xml
 <?xml version="1.0"?>
 <snapshot>
   <type>single</type>
@@ -75,11 +119,40 @@ EOF
 systemctl restart snapperd
 
 print_red "DEBUG: Install MicroOS GNOME to $WORKSNAP"
-zypper -R /.snapshots/$WORKSNAP/snapshot --gpg-auto-import-keys ar -f http://mirrorcache-eu.opensuse.org/tumbleweed/repo/oss/ repo-non-oss
-ZYPP_SINGLE_RPMTRANS=1 zypper -R /.snapshots/$WORKSNAP/snapshot --gpg-auto-import-keys in $PACKAGES
+zypper -R /.snapshots/$WORKSNAP/snapshot --gpg-auto-import-keys ar -f \
+	http://mirrorcache-eu.opensuse.org/tumbleweed/repo/oss/ repo-non-oss
 
+ZYPP_SINGLE_RPMTRANS=1 zypper -R /.snapshots/$WORKSNAP/snapshot \
+	--gpg-auto-import-keys in $PACKAGES
+
+# Grab current fstab, except for last overlay mount
+fstab_content="$(cat /etc/fstab | head -n -1)"
+
+# backup original fstab
+cp /.snapshots/$WORKSNAP/snapshot/etc/fstab /.snapshots/$WORKSNAP/snapshot/etc/fstab.bak
+
+# Create new fstab with current layout, and new overlay mount
+echo "$fstab_content" > /.snapshots/$WORKSNAP/snapshot/etc/fstab
+cat /.snapshots/$WORKSNAP/snapshot/etc/fstab.bak >> /.snapshots/$WORKSNAP/snapshot/etc/fstab
+
+systemctl restart snapperd
+
+cp -r /boot/grub2/* /.snapshots/6/snapshot/boot/grub2/
+
+# Now we set up the boot correctly, tukit call enables us to launch commands in
+# an existing snapshot
+/sbin/tukit call $WORKSNAP dracut --force --regenerate-all
+/sbin/tukit call $WORKSNAP /usr/sbin/grub2-mkconfig -o /boot/grub2/grub.cfg
+/sbin/tukit call $WORKSNAP chcon --reference /boot/grub2/grub.cfg  /.snapshots/$WORKSNAP/snapshot/boot/grub2/grub.cfg
+/sbin/tukit call $WORKSNAP /sbin/pbl --install
+
+# Missing piece, this will make the snapshot actually bootable
+/usr/lib/snapper/plugins/grub --enable $WORKSNAP
+
+/sbin/tukit close $WORKSNAP
+
+
+#TODO - cleanup in case of abort/error
 #TODO - edit etc/fstab to look like a regular t-u snapshots one
 #TODO - populate etc/fstab with etc/fstab from the existing host
-#TODO - fix bootloader
 #TODO - delete var/lib/overlay/1
-#TODO - see if all this stuff actually boots


### PR DESCRIPTION
So now the created snapshot is bootable and works, the missing pieces were the tukit commands:

```sh
/sbin/tukit call $WORKSNAP dracut --force --regenerate-all
/sbin/tukit call $WORKSNAP /usr/sbin/grub2-mkconfig -o /boot/grub2/grub.cfg
/sbin/tukit call $WORKSNAP chcon --reference /boot/grub2/grub.cfg  /.snapshots/$WORKSNAP/snapshot/boot/grub2/grub.cfg
/sbin/tukit call $WORKSNAP /sbin/pbl --install
```

And the snapper grub plugin run, to make the snapshot actually bootable:

```sh
/usr/lib/snapper/plugins/grub --enable $WORKSNAP
```

Also added some packages needed to the base, I've just compared an installed pkg list, to the snapshot one
(grub2-i386-pc-extras, grub2-x86_64-efi-extras were missing)

Other than that, there are still some stuff pending:

- Need to add a cleanup in case of abort or error
- Zypper still asks questions (Like license)
- Need a way to add:
  - Firmwares (maybe there is a pattern for *-all?)
  - correct microcodes (amd-ucode, intel-ucode)
  - add or not VM guest tools (for example yast adds them if detected)
  - x11 drivers for the detected gpu

Other than that seems like it's already functional, thanks a lot @sysrich for this tool! :smile:

Signed-off-by: Luca Di Maio <luca.dimaio1@gmail.com>